### PR TITLE
Modularize UI with storybook and deploy to Netlify

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,0 +1,39 @@
+name: Netlify Chapp UI Storybook
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: nrwl/nx-set-shas@v2
+      - run: npm ci
+
+      - run: npx nx workspace-lint
+      # - run: npx nx format:check
+      - run: npx nx affected --target=build-storybook --parallel=3
+
+        # ( Build to ./dist or other directory... )
+
+      - name: Deploy to Netlify
+        uses: sergeylukin/actions-netlify@add-project-name-to-pr-comment
+        if: hashFiles('./dist/storybook/shared-ui') != ''
+        with:
+          project-name: 'Chapp UI storybook'
+          publish-dir: './dist/storybook/shared-ui'
+          production-branch: main
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Deploying Chapp UI Storybook from GH Actions"
+          enable-pull-request-comment: true
+          overwrites-pull-request-comment: true
+          enable-commit-comment: true
+          enable-deployment-status: false
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: courageous-maamoul-7ad496.netlify.app
+        timeout-minutes: 1

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,0 +1,98 @@
+const path = require('path');
+
+const toPath = (_path) => path.join(process.cwd(), _path);
+
+module.exports = {
+  stories: [],
+  addons: ['@storybook/addon-essentials', '@chakra-ui/storybook-addon'],
+  features: {
+    emotionAlias: false,
+  },
+  babel: async (options) => {
+    return {
+      ...options,
+      presets: [...options.presets, '@babel/preset-react'],
+    };
+  },
+  // uncomment the property below if you want to apply some webpack config globally
+  // webpackFinal: async (config, { configType }) => {
+  //   // Make whatever fine-grained changes you need that should apply to all storybook configs
+
+  //   // Return the altered config
+  //   return config;
+  // },
+  webpackFinal: async (config) => {
+    // config = {
+    //   ...config,
+    //   resolve: {
+    //     ...config.resolve,
+    //     fallback: {
+    //       fs: false,
+    //       net: false,
+    //       tls: false,
+    //     },
+    //     alias: {
+    //       ...config.resolve.alias,
+    //       '@babel/preset-react': toPath('node_modules/@babel/preset-react'),
+    //       '@emotion/core': toPath('node_modules/@emotion/react'),
+    //       '@emotion/styled': toPath('node_modules/@emotion/styled'),
+    //       'emotion-theming': toPath('node_modules/@emotion/react'),
+    //     },
+    //   },
+    // };
+
+// `configType` has a value of 'DEVELOPMENT' or 'PRODUCTION'
+    // You can change the configuration based on that.
+    // 'PRODUCTION' is used when building the static version of storybook.
+
+    // here we use babel-loader
+    config.module.rules.push({
+      test: /\.(ts|tsx)$/,
+      loader: require.resolve('babel-loader'),
+      options: {
+        babelrc: false,
+        presets: [
+          '@babel/preset-typescript',
+          [
+            '@babel/preset-react',
+            {
+              runtime: 'automatic',
+            },
+          ],
+        ],
+        plugins: [
+          ['@babel/plugin-proposal-nullish-coalescing-operator'],
+          ['@babel/plugin-proposal-optional-chaining'],
+        ],
+      },
+    });
+
+    // config.resolve.modules = [
+    //   path.resolve(__dirname, '../', 'node_modules'),
+    //   'node_modules',
+    // ];
+
+    config.resolve.extensions.push('.ts', '.tsx');
+
+    config.resolve = {
+        ...config.resolve,
+        fallback: {
+          fs: false,
+          net: false,
+          tls: false,
+        },
+        alias: {
+          ...config.resolve.alias,
+          '@babel/preset-react': toPath('node_modules/@babel/preset-react'),
+          '@emotion/core': toPath('node_modules/@emotion/react'),
+          '@emotion/styled': toPath('node_modules/@emotion/styled'),
+          'emotion-theming': toPath('node_modules/@emotion/react'),
+        },
+      }
+
+    config.stats = 'verbose';
+
+    // Return the altered config
+    return config;
+  },
+};

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,0 +1,56 @@
+import React from 'react';
+// import * as React from 'react';
+import { ChakraProvider } from '@chakra-ui/react';
+
+import { frontWebsiteTheme } from '../libs/front-website/theme/src';
+
+export const globalTypes = {
+  direction: {
+    name: 'Direction',
+    description: 'Direction for layout',
+    defaultValue: 'LTR',
+    toolbar: {
+      icon: 'globe',
+      items: ['LTR', 'RTL'],
+    },
+  },
+};
+
+const withChakra = (StoryFn, context) => {
+  const { direction } = context.globals;
+  const dir = direction.toLowerCase();
+
+  React.useEffect(() => {
+    document.documentElement.dir = dir;
+  }, [dir]);
+
+  return (
+    <ChakraProvider theme={frontWebsiteTheme}>
+      <div dir={dir} id="story-wrapper" style={{ minHeight: '100vh' }}>
+        <StoryFn />
+      </div>
+    </ChakraProvider>
+  );
+};
+
+export const decorators = [withChakra];
+
+export const parameters = {
+  chakra: {
+    theme: frontWebsiteTheme,
+  },
+  backgrounds: {
+    default: 'blank',
+    values: [
+      {
+        name: 'blank',
+        value: 'white',
+      },
+      {
+        name: 'chapp',
+        value:
+          'linear-gradient(-45deg, #ee7752, #e73c7e, #23a6d5, #23d5ab) 400% 400%',
+      },
+    ],
+  },
+};

--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig.base.json",
+  "exclude": [
+    "../**/*.spec.js",
+    "../**/*.test.js",
+    "../**/*.spec.ts",
+    "../**/*.test.ts",
+    "../**/*.spec.tsx",
+    "../**/*.test.tsx",
+    "../**/*.spec.jsx",
+    "../**/*.test.jsx"
+  ],
+  "include": ["../**/*"]
+}

--- a/apps/front-website/src/app/home/room.tsx
+++ b/apps/front-website/src/app/home/room.tsx
@@ -14,6 +14,7 @@ import { ArrowForwardIcon } from '@chakra-ui/icons';
 
 import { gradientAnimationName } from '@chapp/front-website/theme';
 import { useStoreState, useStoreActions } from '@chapp/shared-state';
+import { MessageCard } from '@chapp/shared-ui';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import MessageForm from './messageform';
@@ -31,11 +32,6 @@ const Room = () => {
   const messagesContainerRef = useRef();
 
   useEffect(() => {
-    loadMessagesThunk();
-    // eslint-disable-next-line
-  }, []);
-
-  useEffect(() => {
     if (messagesContainerRef.current)
       messagesContainerRef.current.scroll({
         top: messagesContainerRef.current.scrollHeight,
@@ -44,8 +40,10 @@ const Room = () => {
   }, [messages]);
 
   useEffect(() => {
+    loadMessagesThunk();
     const timer = setInterval(loadMessagesThunk, 5000);
     return () => clearInterval(timer);
+    // eslint-disable-next-line
   }, []);
 
   return (
@@ -73,26 +71,9 @@ const Room = () => {
           <ul>
             {messages.map((message, index) => {
               return (
-                <Flex key={index} w="100%">
-                  <Avatar
-                    name="Computer"
-                    src="https://avataaars.io/?avatarStyle=Transparent&topType=LongHairStraight&accessoriesType=Blank&hairColor=BrownDark&facialHairType=Blank&clotheType=BlazerShirt&eyeType=Default&eyebrowType=Default&mouthType=Default&skinColor=Light"
-                    bg="blue.300"
-                    mt={2}
-                  ></Avatar>
-                  <Flex
-                    bg="gray.100"
-                    color="black"
-                    minW="100px"
-                    maxW="350px"
-                    my="1"
-                    ml={3}
-                    p="3"
-                    borderRadius={5}
-                  >
-                    <Text>{message.body}</Text>
-                  </Flex>
-                </Flex>
+                <div key={index}>
+                  <MessageCard message={message} />
+                </div>
               );
             })}
           </ul>

--- a/libs/shared/ui/.babelrc
+++ b/libs/shared/ui/.babelrc
@@ -1,0 +1,13 @@
+{
+  "presets": [
+    [
+      "@nrwl/react/babel",
+      {
+        "runtime": "automatic",
+        "useBuiltIns": "usage",
+        "importSource": "@emotion/react"
+      }
+    ]
+  ],
+  "plugins": ["@emotion/babel-plugin"]
+}

--- a/libs/shared/ui/.eslintrc.json
+++ b/libs/shared/ui/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["plugin:@nrwl/nx/react", "../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/shared/ui/.storybook/main.js
+++ b/libs/shared/ui/.storybook/main.js
@@ -1,0 +1,24 @@
+const rootMain = require('../../../../.storybook/main');
+
+module.exports = {
+  ...rootMain,
+
+  core: { ...rootMain.core, builder: 'webpack5' },
+
+  stories: [
+    ...rootMain.stories,
+    '../src/lib/**/*.stories.mdx',
+    '../src/lib/**/*.stories.@(js|jsx|ts|tsx)',
+  ],
+  addons: [...rootMain.addons, '@nrwl/react/plugins/storybook'],
+  webpackFinal: async (config, { configType }) => {
+    // apply any global webpack configs that might have been specified in .storybook/main.js
+    if (rootMain.webpackFinal) {
+      config = await rootMain.webpackFinal(config, { configType });
+    }
+
+    // add your own webpack tweaks if needed
+
+    return config;
+  },
+};

--- a/libs/shared/ui/.storybook/preview.js
+++ b/libs/shared/ui/.storybook/preview.js
@@ -1,0 +1,1 @@
+export * from '../../../../.storybook/preview';

--- a/libs/shared/ui/.storybook/tsconfig.json
+++ b/libs/shared/ui/.storybook/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "emitDecoratorMetadata": true,
+    "outDir": ""
+  },
+  "files": [
+    "../../../../node_modules/@nrwl/react/typings/styled-jsx.d.ts",
+    "../../../../node_modules/@nrwl/react/typings/cssmodule.d.ts",
+    "../../../../node_modules/@nrwl/react/typings/image.d.ts"
+  ],
+  "exclude": [
+    "../**/*.spec.ts",
+    "../**/*.spec.js",
+    "../**/*.spec.tsx",
+    "../**/*.spec.jsx"
+  ],
+  "include": ["../src/**/*", "*.js"]
+}

--- a/libs/shared/ui/README.md
+++ b/libs/shared/ui/README.md
@@ -1,0 +1,7 @@
+# shared-ui
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test shared-ui` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/shared/ui/jest.config.js
+++ b/libs/shared/ui/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  displayName: 'shared-ui',
+  preset: '../../../jest.preset.js',
+  transform: {
+    '^.+\\.[tj]sx?$': 'babel-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../../coverage/libs/shared/ui',
+};

--- a/libs/shared/ui/project.json
+++ b/libs/shared/ui/project.json
@@ -1,0 +1,23 @@
+{
+  "root": "libs/shared/ui",
+  "sourceRoot": "libs/shared/ui/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/shared/ui/**/*.{ts,tsx,js,jsx}"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/libs/shared/ui"],
+      "options": {
+        "jestConfig": "libs/shared/ui/jest.config.js",
+        "passWithNoTests": true
+      }
+    }
+  }
+}

--- a/libs/shared/ui/project.json
+++ b/libs/shared/ui/project.json
@@ -18,6 +18,37 @@
         "jestConfig": "libs/shared/ui/jest.config.js",
         "passWithNoTests": true
       }
+    },
+    "storybook": {
+      "executor": "@nrwl/storybook:storybook",
+      "options": {
+        "uiFramework": "@storybook/react",
+        "port": 4400,
+        "config": {
+          "configFolder": "libs/shared/ui/.storybook"
+        }
+      },
+      "configurations": {
+        "ci": {
+          "quiet": true
+        }
+      }
+    },
+    "build-storybook": {
+      "executor": "@nrwl/storybook:build",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "uiFramework": "@storybook/react",
+        "outputPath": "dist/storybook/shared-ui",
+        "config": {
+          "configFolder": "libs/shared/ui/.storybook"
+        }
+      },
+      "configurations": {
+        "ci": {
+          "quiet": true
+        }
+      }
     }
   }
 }

--- a/libs/shared/ui/src/index.ts
+++ b/libs/shared/ui/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/shared-ui';

--- a/libs/shared/ui/src/index.ts
+++ b/libs/shared/ui/src/index.ts
@@ -1,1 +1,2 @@
+export * from './lib/message-card/message-card';
 export * from './lib/shared-ui';

--- a/libs/shared/ui/src/lib/message-card/message-card.spec.tsx
+++ b/libs/shared/ui/src/lib/message-card/message-card.spec.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+
+import MessageCard from './message-card';
+
+describe('MessageCard', () => {
+  it('should render successfully', () => {
+    const { baseElement } = render(<MessageCard />);
+    expect(baseElement).toBeTruthy();
+  });
+});

--- a/libs/shared/ui/src/lib/message-card/message-card.stories.tsx
+++ b/libs/shared/ui/src/lib/message-card/message-card.stories.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { MessageCard, MessageCardProps } from './message-card';
+
+export default {
+  component: MessageCard,
+  title: 'MessageCard',
+  argTypes: {},
+  args: {
+    message: {
+      body: 'Hello there!',
+      userId: 2,
+      roomId: 3,
+    },
+  },
+  parameters: {
+    backgrounds: {
+      default: 'chapp',
+    },
+  },
+} as Meta;
+
+const Template: Story<MessageCardProps> = (args) => <MessageCard {...args} />;
+
+export const Primary = Template.bind({});
+Primary.args = {};

--- a/libs/shared/ui/src/lib/message-card/message-card.tsx
+++ b/libs/shared/ui/src/lib/message-card/message-card.tsx
@@ -1,17 +1,34 @@
-import styled from '@emotion/styled';
+import React from 'react';
+import { IMessage } from '@chapp/api-interfaces';
+import { Flex, Text, Avatar } from '@chakra-ui/react';
 
 /* eslint-disable-next-line */
-export interface MessageCardProps {}
+export interface MessageCardProps {
+  message: IMessage;
+}
 
-const StyledMessageCard = styled.div`
-  color: pink;
-`;
-
-export function MessageCard(props: MessageCardProps) {
+export function MessageCard({ message }: MessageCardProps) {
   return (
-    <StyledMessageCard>
-      <h1>Welcome to MessageCard!</h1>
-    </StyledMessageCard>
+    <Flex w="100%">
+      <Avatar
+        name="Computer"
+        src="https://avataaars.io/?avatarStyle=Transparent&topType=LongHairStraight&accessoriesType=Blank&hairColor=BrownDark&facialHairType=Blank&clotheType=BlazerShirt&eyeType=Default&eyebrowType=Default&mouthType=Default&skinColor=Light"
+        bg="blue.300"
+        mt={2}
+      ></Avatar>
+      <Flex
+        bg="gray.100"
+        color="black"
+        minW="100px"
+        maxW="350px"
+        my="1"
+        ml={3}
+        p="3"
+        borderRadius={5}
+      >
+        <Text>{message.body}</Text>
+      </Flex>
+    </Flex>
   );
 }
 

--- a/libs/shared/ui/src/lib/message-card/message-card.tsx
+++ b/libs/shared/ui/src/lib/message-card/message-card.tsx
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+
+/* eslint-disable-next-line */
+export interface MessageCardProps {}
+
+const StyledMessageCard = styled.div`
+  color: pink;
+`;
+
+export function MessageCard(props: MessageCardProps) {
+  return (
+    <StyledMessageCard>
+      <h1>Welcome to MessageCard!</h1>
+    </StyledMessageCard>
+  );
+}
+
+export default MessageCard;

--- a/libs/shared/ui/src/lib/shared-ui.spec.tsx
+++ b/libs/shared/ui/src/lib/shared-ui.spec.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+
+import SharedUi from './shared-ui';
+
+describe('SharedUi', () => {
+  it('should render successfully', () => {
+    const { baseElement } = render(<SharedUi />);
+    expect(baseElement).toBeTruthy();
+  });
+});

--- a/libs/shared/ui/src/lib/shared-ui.tsx
+++ b/libs/shared/ui/src/lib/shared-ui.tsx
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+
+/* eslint-disable-next-line */
+export interface SharedUiProps {}
+
+const StyledSharedUi = styled.div`
+  color: pink;
+`;
+
+export function SharedUi(props: SharedUiProps) {
+  return (
+    <StyledSharedUi>
+      <h1>Welcome to SharedUi!</h1>
+    </StyledSharedUi>
+  );
+}
+
+export default SharedUi;

--- a/libs/shared/ui/tsconfig.json
+++ b/libs/shared/ui/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "@emotion/react",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/shared/ui/tsconfig.json
+++ b/libs/shared/ui/tsconfig.json
@@ -21,6 +21,9 @@
     },
     {
       "path": "./tsconfig.spec.json"
+    },
+    {
+      "path": "./.storybook/tsconfig.json"
     }
   ]
 }

--- a/libs/shared/ui/tsconfig.lib.json
+++ b/libs/shared/ui/tsconfig.lib.json
@@ -16,7 +16,11 @@
     "**/*.spec.js",
     "**/*.test.js",
     "**/*.spec.jsx",
-    "**/*.test.jsx"
+    "**/*.test.jsx",
+    "**/*.stories.ts",
+    "**/*.stories.js",
+    "**/*.stories.jsx",
+    "**/*.stories.tsx"
   ],
   "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
 }

--- a/libs/shared/ui/tsconfig.lib.json
+++ b/libs/shared/ui/tsconfig.lib.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "types": ["node"]
+  },
+  "files": [
+    "../../../node_modules/@nrwl/react/typings/cssmodule.d.ts",
+    "../../../node_modules/@nrwl/react/typings/image.d.ts"
+  ],
+  "exclude": [
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "**/*.spec.tsx",
+    "**/*.test.tsx",
+    "**/*.spec.js",
+    "**/*.test.js",
+    "**/*.spec.jsx",
+    "**/*.test.jsx"
+  ],
+  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
+}

--- a/libs/shared/ui/tsconfig.spec.json
+++ b/libs/shared/ui/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/nx.json
+++ b/nx.json
@@ -17,7 +17,13 @@
     "default": {
       "runner": "@nrwl/workspace/tasks-runners/default",
       "options": {
-        "cacheableOperations": ["build", "lint", "test", "e2e"]
+        "cacheableOperations": [
+          "build",
+          "lint",
+          "test",
+          "e2e",
+          "build-storybook"
+        ]
       }
     }
   },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -18,7 +18,8 @@
       "@chapp/api-interfaces": ["libs/api-interfaces/src/index.ts"],
       "@chapp/front-website/theme": ["libs/front-website/theme/src/index.ts"],
       "@chapp/shared-data": ["libs/shared/data/src/index.ts"],
-      "@chapp/shared-state": ["libs/shared/state/src/index.ts"]
+      "@chapp/shared-state": ["libs/shared/state/src/index.ts"],
+      "@chapp/shared/ui": ["libs/shared/ui/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]

--- a/workspace.json
+++ b/workspace.json
@@ -7,6 +7,7 @@
     "front-website-e2e": "apps/front-website-e2e",
     "front-website-theme": "libs/front-website/theme",
     "shared-data": "libs/shared/data",
-    "shared-state": "libs/shared/state"
+    "shared-state": "libs/shared/state",
+    "shared-ui": "libs/shared/ui"
   }
 }


### PR DESCRIPTION
## What

- create `@chapp/shared-ui` library
- install storybook + configure (support app backgrounds, chakra-ui, compilation specifics, etc.)
- move hardcoded message card component into `import { MessageCard } from '@chapp/shared-ui'`
- add `MessageCard` to storybook

<img width="927" alt="Screen Shot 2022-05-26 at 18 58 12" src="https://user-images.githubusercontent.com/720339/170526621-848530cf-e7ae-491b-9cb2-102b135dcc3c.png">
