### PR TITLE
feat: move <MessageForm /> to shared-ui+storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,6 +2,9 @@ import React from 'react';
 // import * as React from 'react';
 import { ChakraProvider } from '@chakra-ui/react';
 
+import { StoreProvider } from 'easy-peasy';
+import { store } from '@chapp/shared-state';
+
 import { frontWebsiteTheme } from '../libs/front-website/theme/src';
 
 export const globalTypes = {
@@ -33,7 +36,22 @@ const withChakra = (StoryFn, context) => {
   );
 };
 
-export const decorators = [withChakra];
+const withEasyPeasy = (StoryFn) => {
+  /* const { direction } = context.globals; */
+  // const dir = direction.toLowerCase();
+
+  // React.useEffect(() => {
+  //   document.documentElement.dir = dir;
+  // }, [dir]);
+
+  return (
+    <StoreProvider store={store}>
+      <StoryFn />
+    </StoreProvider>
+  );
+};
+
+export const decorators = [withChakra, withEasyPeasy];
 
 export const parameters = {
   chakra: {

--- a/apps/front-website/src/app/home/room.tsx
+++ b/apps/front-website/src/app/home/room.tsx
@@ -1,15 +1,10 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
 import { useRef, useEffect } from 'react';
 import { Flex, HStack, Button, Text, VStack, Box } from '@chakra-ui/react';
 import { ArrowForwardIcon } from '@chakra-ui/icons';
 
 import { gradientAnimationName } from '@chapp/front-website/theme';
 import { useStoreState, useStoreActions } from '@chapp/shared-state';
-import { MessageCard } from '@chapp/shared-ui';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import MessageForm from './messageform';
+import { MessageForm, MessageCard } from '@chapp/shared-ui';
 
 const Room = () => {
   const { room } = useStoreState((store) => store['roomModel']);
@@ -21,7 +16,7 @@ const Room = () => {
     (actions) => actions['messagesModel']
   );
 
-  const messagesContainerRef = useRef();
+  const messagesContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (messagesContainerRef.current)

--- a/libs/shared/ui/src/index.ts
+++ b/libs/shared/ui/src/index.ts
@@ -1,2 +1,3 @@
+export * from './lib/message-form/message-form';
 export * from './lib/message-card/message-card';
 export * from './lib/shared-ui';

--- a/libs/shared/ui/src/lib/message-form/message-form.spec.tsx
+++ b/libs/shared/ui/src/lib/message-form/message-form.spec.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+
+import MessageForm from './message-form';
+
+describe('MessageForm', () => {
+  it('should render successfully', () => {
+    const { baseElement } = render(<MessageForm />);
+    expect(baseElement).toBeTruthy();
+  });
+});

--- a/libs/shared/ui/src/lib/message-form/message-form.stories.tsx
+++ b/libs/shared/ui/src/lib/message-form/message-form.stories.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import { MessageForm } from './message-form';
+
+export default {
+  component: MessageForm,
+  title: 'MessageForm',
+  argTypes: {},
+  args: {},
+  parameters: {
+    backgrounds: {
+      default: 'chapp',
+    },
+  },
+} as Meta;
+
+const Template: Story = (args) => <MessageForm {...args} />;
+
+export const Primary = Template.bind({});
+Primary.args = {};

--- a/libs/shared/ui/src/lib/message-form/message-form.tsx
+++ b/libs/shared/ui/src/lib/message-form/message-form.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
 import { useEffect, useRef } from 'react';
 import {
   Box,
@@ -18,11 +16,11 @@ const schema = Yup.object().shape({
   msg: Yup.string().required('No empty messages, sorry'),
 });
 
-const MessageForm = () => {
+export function MessageForm() {
   const { sendMessageThunk } = useStoreActions(
     (actions) => actions['messageModel']
   );
-  const messageInputRef = useRef();
+  const messageInputRef = useRef<HTMLInputElement>(null);
   useEffect(() => {
     if (messageInputRef.current) messageInputRef.current.focus();
     // eslint-disable-next-line
@@ -51,7 +49,9 @@ const MessageForm = () => {
           .catch((err) => {
             setSubmitting(false);
             setStatus('error');
-            const errors = {};
+            const errors: {
+              [key: string]: string;
+            } = {};
             Object.keys(values).forEach((key, idx) => {
               if (err && err.errors && err.errors[idx]) {
                 errors[key] = err.errors[idx];
@@ -67,8 +67,16 @@ const MessageForm = () => {
           <Box className="ui-form u-shadow" p={2}>
             <HStack w="100%" spacing={3} alignItems="start">
               <Field type="msg" name="msg">
-                {({ field, form }) => (
-                  <FormControl isInvalid={form.errors.msg && form.touched.msg}>
+                {({
+                  field,
+                  form,
+                }: {
+                  field: string;
+                  form: { touched: { msg: string }; errors: { msg: string } };
+                }) => (
+                  <FormControl
+                    isInvalid={!!(form.errors.msg && form.touched.msg)}
+                  >
                     <Input
                       {...field}
                       variant="login"
@@ -97,6 +105,6 @@ const MessageForm = () => {
       )}
     </Formik>
   );
-};
+}
 
 export default MessageForm;


### PR DESCRIPTION
## What

Migrate `<MessageForm />` to shared-ui library + add it to Storybook + enable Typescript

<img width="1792" alt="Screen Shot 2022-05-28 at 5 10 44" src="https://user-images.githubusercontent.com/720339/170805696-99c7b253-2d36-4201-9891-5c899d52cbd8.png">

## Why

Small refactor after the feature was developed in rush, that increases reusability, testability, separation of concerns in the code.

## CLI commands used during development

```
npx nx g @nrwl/react:component message-form --project=shared-ui --export
```