### PR TITLE
feat: shorten external links

### DIFF
--- a/libs/front-website/theme/src/lib/encode.ts
+++ b/libs/front-website/theme/src/lib/encode.ts
@@ -1,0 +1,41 @@
+// eslint-disable-next-line
+// @ts-nocheck
+const symbols = /[\r\n"%#()<>?[\\\]^`{|}]/g;
+
+function addNameSpace(data) {
+  if (data.indexOf('http://www.w3.org/2000/svg') < 0) {
+    data = data.replace(/<svg/g, "<svg xmlns='http://www.w3.org/2000/svg'");
+  }
+
+  return data;
+}
+
+function encodeSVG(data) {
+  // Use single quotes instead of double to avoid encoding.
+  if (data.indexOf('"') >= 0) {
+    data = data.replace(/"/g, "'");
+  }
+
+  data = data.replace(/>\s{1,}</g, '><');
+  data = data.replace(/\s{2,}/g, ' ');
+
+  return data.replace(symbols, encodeURIComponent);
+}
+
+export const encode = function (svg, fill) {
+  if (fill) {
+    svg = svg.replace(/<svg/g, `<svg fill="${fill}"`);
+  }
+  const namespaced = addNameSpace(svg);
+  const dimensionsRemoved = namespaced
+    .replace(/height="\w*" /g, '')
+    .replace(/width="\w*" /g, '')
+    .replace(/height='\w*' /g, '')
+    .replace(/width='\w*' /g, '');
+  const encoded = encodeSVG(dimensionsRemoved);
+
+  const header = 'data:image/svg+xml,';
+  const dataUrl = header + encoded;
+
+  return `url("${dataUrl}")`;
+};

--- a/libs/front-website/theme/src/lib/front-website-theme.ts
+++ b/libs/front-website/theme/src/lib/front-website-theme.ts
@@ -1,6 +1,7 @@
 // import { useState, useEffect } from 'react';
 import { keyframes } from '@chakra-ui/react';
 import { extendTheme } from '@chakra-ui/react';
+import { encode } from './encode';
 
 const dylanAnimationKeyframesName = keyframes`
   50% {
@@ -297,6 +298,20 @@ export const frontWebsiteTheme = extendTheme({
       },
       '[data-show]:not([data-active])': {
         display: 'none',
+      },
+      'a[href^="https"]::after': {
+        content: "''",
+        width: '11px',
+        height: '11px',
+        marginLeft: '4px',
+        backgroundImage: encode(
+          "<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'><path fill-rule='evenodd' d='M8.636 3.5a.5.5 0 0 0-.5-.5H1.5A1.5 1.5 0 0 0 0 4.5v10A1.5 1.5 0 0 0 1.5 16h10a1.5 1.5 0 0 0 1.5-1.5V7.864a.5.5 0 0 0-1 0V14.5a.5.5 0 0 1-.5.5h-10a.5.5 0 0 1-.5-.5v-10a.5.5 0 0 1 .5-.5h6.636a.5.5 0 0 0 .5-.5z'/><path fill-rule='evenodd' d='M16 .5a.5.5 0 0 0-.5-.5h-5a.5.5 0 0 0 0 1h3.793L6.146 9.146a.5.5 0 1 0 .708.708L15 1.707V5.5a.5.5 0 0 0 1 0v-5z'/></svg>",
+          '#0d6967'
+        ),
+        backgroundPosition: 'center',
+        backgroundRepeat: 'no-repeat',
+        backgroundSize: 'contain',
+        display: 'inline-block',
       },
     },
   },

--- a/libs/shared/ui/src/lib/message-card/message-card.tsx
+++ b/libs/shared/ui/src/lib/message-card/message-card.tsx
@@ -74,7 +74,7 @@ export function MessageCard({
                 key={key}
                 rel="noreferrer"
               >
-                {decoratedText}
+                {decoratedText.slice(0, 15)}...
               </Link>
             )}
           >


### PR DESCRIPTION
## What

<img width="468" alt="Screen Shot 2022-06-02 at 5 41 17" src="https://user-images.githubusercontent.com/720339/171541392-c7c80091-5074-49e4-804d-c3f212480271.png">

## Why

Preventing long URLs from forcing messages container to be wider than viewport and thus overflowing over the right edge of the viewport, as shown in the "Before" screenshot below:

### Before

<img width="398" alt="Screen Shot 2022-06-02 at 5 42 32" src="https://user-images.githubusercontent.com/720339/171542001-dd3ec4b3-f361-488b-9bf4-2512e07e47f2.png">

### After

<img width="391" alt="Screen Shot 2022-06-02 at 5 48 24" src="https://user-images.githubusercontent.com/720339/171542531-cc55408d-f57c-4758-a38d-c1f14dae03af.png">
